### PR TITLE
Allow all IPs to access `/postmark` endpoint

### DIFF
--- a/.nomad/conf/nginx.conf
+++ b/.nomad/conf/nginx.conf
@@ -22,5 +22,11 @@ server {
     allow all;
   }
 
+  location = /postmark {
+    uwsgi_pass ${NOMAD_JOB_NAME};
+
+    allow all;
+  }
+
   location /static/ {}
 }


### PR DESCRIPTION
AWS is blocked by default